### PR TITLE
Some fixes and additions

### DIFF
--- a/src/StrokerForm/Renderer/AbstractRenderer.php
+++ b/src/StrokerForm/Renderer/AbstractRenderer.php
@@ -160,11 +160,19 @@ abstract class AbstractRenderer implements RendererInterface, TranslatorAwareInt
     }
 
     /**
+     * @param array $options
      * @return AbstractOptions
      */
-    public function getOptions()
+    public function getOptions(array $options = array())
     {
-        return $this->options;
+        if(!count($options))
+        {
+            return $this->options;
+        }
+
+        $newOptions = clone $this->options;
+        $newOptions->setFromArray($options);
+        return $newOptions;
     }
 
     /**

--- a/src/StrokerForm/Renderer/AbstractValidateRenderer.php
+++ b/src/StrokerForm/Renderer/AbstractValidateRenderer.php
@@ -24,8 +24,9 @@ abstract class AbstractValidateRenderer extends AbstractRenderer
      * @param string                          $formAlias
      * @param \Zend\View\Renderer\PhpRenderer $view
      * @param \Zend\Form\FormInterface        $form
+     * @param array                           $options
      */
-    public function preRenderForm($formAlias, View $view, FormInterface $form = null)
+    public function preRenderForm($formAlias, View $view, FormInterface $form = null, array $options = array())
     {
         if ($form === null) {
             $form = $this->getFormManager()->get($formAlias);

--- a/src/StrokerForm/Renderer/JqueryValidate/Options.php
+++ b/src/StrokerForm/Renderer/JqueryValidate/Options.php
@@ -24,6 +24,11 @@ class Options extends \StrokerForm\Renderer\Options
     private $useTwitterBootstrap = true;
 
     /**
+     * @var string
+     */
+    private $initializeTrigger = '$(document).ready(function(){%s});';
+
+    /**
      * @return array
      */
     public function getValidateOptions()
@@ -64,5 +69,23 @@ class Options extends \StrokerForm\Renderer\Options
     public function setUseTwitterBootstrap($useTwitterBootstrap)
     {
         $this->useTwitterBootstrap = $useTwitterBootstrap;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInitializeTrigger()
+    {
+        return $this->initializeTrigger;
+    }
+
+    /**
+     * @param string $initializeTrigger
+     * @return Options
+     */
+    public function setInitializeTrigger($initializeTrigger)
+    {
+        $this->initializeTrigger = $initializeTrigger;
+        return $this;
     }
 }

--- a/src/StrokerForm/Renderer/RendererCollection.php
+++ b/src/StrokerForm/Renderer/RendererCollection.php
@@ -58,12 +58,13 @@ class RendererCollection extends AbstractRenderer
      * @param  string                          $formAlias
      * @param  \Zend\View\Renderer\PhpRenderer $view
      * @param  \Zend\Form\FormInterface        $form
+     * @param array                            $options
      * @return mixed
      */
-    public function preRenderForm($formAlias, View $view, FormInterface $form = null)
+    public function preRenderForm($formAlias, View $view, FormInterface $form = null, array $options = array())
     {
         foreach ($this->getRenderers() as $renderer) {
-            $renderer->preRenderForm($formAlias, $view, $form);
+            $renderer->preRenderForm($formAlias, $view, $form, $options);
         }
     }
 

--- a/src/StrokerForm/Renderer/RendererInterface.php
+++ b/src/StrokerForm/Renderer/RendererInterface.php
@@ -24,8 +24,10 @@ interface RendererInterface
      * @param string                   $formAlias
      * @param View                     $view
      * @param \Zend\Form\FormInterface $form
+     * @param array                    $options
+     * @return
      */
-    public function preRenderForm($formAlias, View $view, FormInterface $form = null);
+    public function preRenderForm($formAlias, View $view, FormInterface $form = null, array $options = array());
 
     /**
      * Excecuted before the ZF2 view helper renders the element

--- a/src/StrokerForm/View/Helper/FormPrepare.php
+++ b/src/StrokerForm/View/Helper/FormPrepare.php
@@ -33,9 +33,10 @@ class FormPrepare extends AbstractHelper
     /**
      * @param string                   $formAlias
      * @param \Zend\Form\FormInterface $form
+     * @param array $options
      */
-    public function __invoke($formAlias, FormInterface $form = null)
+    public function __invoke($formAlias, FormInterface $form = null, array $options = array())
     {
-        $this->renderer->preRenderForm($formAlias, $this->getView(), $form);
+        $this->renderer->preRenderForm($formAlias, $this->getView(), $form, $options);
     }
 }


### PR DESCRIPTION
- Added option to overwrite options for a renderere during rendering. This way you can use the same validator in different ways. 
- Added the option to define your own piece of js for the initialisation of the jquery validator. Now it can be used in forms rendered later then the onload event.
- Changed the jquery selector to form[name="<form name>"]
