### PR TITLE
Fix for change in TranslatorAwareInterface 

### DIFF
--- a/src/StrokerForm/Renderer/AbstractRenderer.php
+++ b/src/StrokerForm/Renderer/AbstractRenderer.php
@@ -12,6 +12,7 @@ namespace StrokerForm\Renderer;
 
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\Mvc\Router\RouteInterface;
 use Zend\Stdlib\AbstractOptions;
 use StrokerForm\FormManager;
@@ -62,13 +63,13 @@ abstract class AbstractRenderer implements RendererInterface, TranslatorAwareInt
     /**
      * Sets translator to use in helper
      *
-     * @param Translator $translator [optional] translator.
+     * @param TranslatorInterface $translator [optional] translator.
      *                                 Default is null, which sets no translator.
      * @param string $textDomain [optional] text domain
      *                                 Default is null, which skips setTranslatorTextDomain
      * @return AbstractTranslatorHelper
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
         if (null !== $textDomain) {

--- a/src/StrokerForm/Renderer/JqueryValidate/Rule/AbstractRule.php
+++ b/src/StrokerForm/Renderer/JqueryValidate/Rule/AbstractRule.php
@@ -12,6 +12,7 @@ namespace StrokerForm\Renderer\JqueryValidate\Rule;
 
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\Validator\AbstractValidator;
 
 abstract class AbstractRule implements
@@ -52,11 +53,11 @@ abstract class AbstractRule implements
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator
+     * @param  TranslatorInterface $translator
      * @param  string     $textDomain
      * @return mixed
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
 


### PR DESCRIPTION
The setTranslator method expects a TranslatorInterface instead of a Translator now.
