### PR TITLE
Fix when input filter has no filter for specific form element

### DIFF
--- a/src/StrokerForm/Renderer/AbstractValidateRenderer.php
+++ b/src/StrokerForm/Renderer/AbstractValidateRenderer.php
@@ -70,7 +70,9 @@ abstract class AbstractValidateRenderer extends AbstractRenderer
         }
 
         foreach ($formOrFieldset->getFieldsets() as $key => $fieldset) {
-            $foundValidators = array_merge($foundValidators, $this->extractValidatorsForForm($fieldset, $inputFilter->get($key)));
+            if ($inputFilter->has($key)) {
+                $foundValidators = array_merge($foundValidators, $this->extractValidatorsForForm($fieldset, $inputFilter->get($key)));
+            }
         }
 
         return $foundValidators;


### PR DESCRIPTION
Added check when fetching input filters if the key exists for forms like (http://framework.zend.com/manual/current/en/modules/zend.form.collections.html).